### PR TITLE
removed sharedInstance in JudoKit

### DIFF
--- a/Example-ObjC/JudoKitObjCExample/ViewController.m
+++ b/Example-ObjC/JudoKitObjCExample/ViewController.m
@@ -10,6 +10,7 @@
 #import "DetailViewController.h"
 
 @import JudoKit;
+@import Judo;
 
 typedef NS_ENUM(NSUInteger, TableViewContent) {
     TableViewContentPayment,
@@ -86,7 +87,7 @@ static NSString * const kCellIdentifier     = @"com.judo.judopaysample.tableview
 }
 
 - (IBAction)AVSValueChanged:(UISwitch *)theSwitch {
-    JudoKit.sharedInstance.avsEnabled = theSwitch.on;
+    JudoKit.avsEnabled = theSwitch.on;
 }
 
 #pragma mark - UITableViewDataSource
@@ -165,60 +166,68 @@ static NSString * const kCellIdentifier     = @"com.judo.judopaysample.tableview
 
 - (void)paymentOperation {
     NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"25.0"];
-    [[JudoKit sharedInstance] payment:judoID
-                               amount:amount
-                             currency:nil
-                               payRef:@"payment reference"
-                              consRef:@"consumer reference"
-                             metaData:nil
-                           completion:^(NSArray * response, NSError * error) {
-                               if (error || response.count == 0) {
-                                   _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
-                                   [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
-                                   return; // BAIL
-                               }
-                               NSDictionary *JSON = response[0];
-                               if (JSON[@"cardDetails"]) {
-                                   self.cardDetails = JSON[@"cardDetails"];
-                               }
-                               UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-                               DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
-                               viewController.infoDict = JSON;
-                               [self.navigationController pushViewController:viewController animated:YES];
-                           } errorHandler:^(NSError * error) {
-                               // handle non-fatal error
-                           }];
+    [JudoKit payment:judoID
+              amount:amount
+            currency:nil
+              payRef:@"payment reference"
+             consRef:@"consumer reference"
+            metaData:nil
+          completion:^(NSArray * response, NSError * error) {
+              if (error || response.count == 0) {
+                  _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
+                  [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+                  return; // BAIL
+              }
+              NSDictionary *JSON = response[0];
+              if (JSON[@"cardDetails"]) {
+                  self.cardDetails = JSON[@"cardDetails"];
+              }
+              UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+              DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
+              viewController.infoDict = JSON;
+              [self.navigationController pushViewController:viewController animated:YES];
+          } errorHandler:^(NSError * error) {
+              // unfortunately due to restrictions an enum that conforms to ErrorType cant also be exposed to objective C, so we have to use the int directly
+              if ([error.domain isEqualToString:@"com.judopay.error"] && error.code == -999) {
+                  [self dismissViewControllerAnimated:YES completion:nil];
+              }
+              // handle non-fatal error
+          }];
 }
 
 - (void)preAuthOperation {
     NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"25.0"];
-    [[JudoKit sharedInstance] preAuth:judoID
-                               amount:amount
-                             currency:nil
-                               payRef:@"payment reference"
-                              consRef:@"consumer reference"
-                             metaData:nil
-                           completion:^(NSArray * response, NSError * error) {
-                               if (error || response.count == 0) {
-                                   _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
-                                   [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
-                                   return; // BAIL
-                               }
-                               NSDictionary *JSON = response[0];
-                               if (JSON[@"cardDetails"]) {
-                                   self.cardDetails = JSON[@"cardDetails"];
-                               }
-                               UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-                               DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
-                               viewController.infoDict = JSON;
-                               [self.navigationController pushViewController:viewController animated:YES];
-                           } errorHandler:^(NSError * error) {
-                               // handle non-fatal error
-                           }];
+    [JudoKit preAuth:judoID
+              amount:amount
+            currency:nil
+              payRef:@"payment reference"
+             consRef:@"consumer reference"
+            metaData:nil
+          completion:^(NSArray * response, NSError * error) {
+              if (error || response.count == 0) {
+                  _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
+                  [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+                  return; // BAIL
+              }
+              NSDictionary *JSON = response[0];
+              if (JSON[@"cardDetails"]) {
+                  self.cardDetails = JSON[@"cardDetails"];
+              }
+              UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+              DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
+              viewController.infoDict = JSON;
+              [self.navigationController pushViewController:viewController animated:YES];
+          } errorHandler:^(NSError * error) {
+              // unfortunately due to restrictions an enum that conforms to ErrorType cant also be exposed to objective C, so we have to use the int directly
+              if ([error.domain isEqualToString:@"com.judopay.error"] && error.code == -999) {
+                  [self dismissViewControllerAnimated:YES completion:nil];
+              }
+              // handle non-fatal error
+          }];
 }
 
 - (void)createCardTokenOperation {
-    [[JudoKit sharedInstance] registerCard:judoID amount:[NSDecimalNumber decimalNumberWithString:@"1.01"] currency:nil payRef:@"payRef" consRef:@"consRef" metaData:nil completion:^(NSArray * response, NSError * error) {
+    [JudoKit registerCard:judoID amount:[NSDecimalNumber decimalNumberWithString:@"1.01"] currency:nil payRef:@"payRef" consRef:@"consRef" metaData:nil completion:^(NSArray * response, NSError * error) {
         if (error && response.count == 0) {
             _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
             [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
@@ -229,38 +238,46 @@ static NSString * const kCellIdentifier     = @"com.judo.judopaysample.tableview
             self.cardDetails = JSON[@"cardDetails"];
         }
     } errorHandler:^(NSError * error) {
-        
+        // unfortunately due to restrictions an enum that conforms to ErrorType cant also be exposed to objective C, so we have to use the int directly
+        if ([error.domain isEqualToString:@"com.judopay.error"] && error.code == -999) {
+            [self dismissViewControllerAnimated:YES completion:nil];
+        }
+        // handle non-fatal error
     }];
 }
 
 - (void)tokenPaymentOperation {
     if (self.cardDetails) {
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"25.0"];
-        [[JudoKit sharedInstance] tokenPayment:judoID
-                                        amount:amount
-                                      currency:nil
-                                        payRef:@"payment reference"
-                                       consRef:@"consumer reference"
-                                      metaData:nil
-                                   cardDetails:self.cardDetails
-                                 consumerToken:self.cardDetails[@"consumerToken"]
-                                    completion:^(NSArray * response, NSError * error) {
-                                        if (error || response.count == 0) {
-                                            _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
-                                            [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
-                                            return; // BAIL
-                                        }
-                                        NSDictionary *JSON = response[0];
-                                        if (JSON[@"cardDetails"]) {
-                                            self.cardDetails = JSON[@"cardDetails"];
-                                        }
-                                        UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-                                        DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
-                                        viewController.infoDict = JSON;
-                                        [self.navigationController pushViewController:viewController animated:YES];
-                                    } errorHandler:^(NSError * error) {
-                                        // handle non-fatal error
-                                    }];
+        [JudoKit tokenPayment:judoID
+                       amount:amount
+                     currency:nil
+                       payRef:@"payment reference"
+                      consRef:@"consumer reference"
+                     metaData:nil
+                  cardDetails:self.cardDetails
+                consumerToken:self.cardDetails[@"consumerToken"]
+                   completion:^(NSArray * response, NSError * error) {
+                       if (error || response.count == 0) {
+                           _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
+                           [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+                           return; // BAIL
+                       }
+                       NSDictionary *JSON = response[0];
+                       if (JSON[@"cardDetails"]) {
+                           self.cardDetails = JSON[@"cardDetails"];
+                       }
+                       UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+                       DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
+                       viewController.infoDict = JSON;
+                       [self.navigationController pushViewController:viewController animated:YES];
+                   } errorHandler:^(NSError * error) {
+                       // unfortunately due to restrictions an enum that conforms to ErrorType cant also be exposed to objective C, so we have to use the int directly
+                       if ([error.domain isEqualToString:@"com.judopay.error"] && error.code == -999) {
+                           [self dismissViewControllerAnimated:YES completion:nil];
+                       }
+                       // handle non-fatal error
+                   }];
     } else {
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"you need to create a card token before you can do a pre auth" preferredStyle:UIAlertControllerStyleAlert];
         [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
@@ -271,31 +288,35 @@ static NSString * const kCellIdentifier     = @"com.judo.judopaysample.tableview
 - (void)tokenPreAuthOperation {
     if (self.cardDetails) {
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:@"25.0"];
-        [[JudoKit sharedInstance] tokenPreAuth:judoID
-                                        amount:amount
-                                      currency:nil
-                                        payRef:@"payment reference"
-                                       consRef:@"consumer reference"
-                                      metaData:nil
-                                   cardDetails:self.cardDetails
-                                 consumerToken:self.cardDetails[@"consumerToken"]
-                                    completion:^(NSArray * response, NSError * error) {
-                                        if (error || response.count == 0) {
-                                            _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
-                                            [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
-                                            return; // BAIL
-                                        }
-                                        NSDictionary *JSON = response[0];
-                                        if (JSON[@"cardDetails"]) {
-                                            self.cardDetails = JSON[@"cardDetails"];
-                                        }
-                                        UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-                                        DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
-                                        viewController.infoDict = JSON;
-                                        [self.navigationController pushViewController:viewController animated:YES];
-                                    } errorHandler:^(NSError * error) {
-                                        // handle non-fatal error
-                                    }];
+        [JudoKit tokenPreAuth:judoID
+                       amount:amount
+                     currency:nil
+                       payRef:@"payment reference"
+                      consRef:@"consumer reference"
+                     metaData:nil
+                  cardDetails:self.cardDetails
+                consumerToken:self.cardDetails[@"consumerToken"]
+                   completion:^(NSArray * response, NSError * error) {
+                       if (error || response.count == 0) {
+                           _alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"there was an error performing the operation" preferredStyle:UIAlertControllerStyleAlert];
+                           [_alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+                           return; // BAIL
+                       }
+                       NSDictionary *JSON = response[0];
+                       if (JSON[@"cardDetails"]) {
+                           self.cardDetails = JSON[@"cardDetails"];
+                       }
+                       UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+                       DetailViewController *viewController = [sb instantiateViewControllerWithIdentifier:@"detailviewcontroller"];
+                       viewController.infoDict = JSON;
+                       [self.navigationController pushViewController:viewController animated:YES];
+                   } errorHandler:^(NSError * error) {
+                       // unfortunately due to restrictions an enum that conforms to ErrorType cant also be exposed to objective C, so we have to use the int directly
+                       if ([error.domain isEqualToString:@"com.judopay.error"] && error.code == -999) {
+                           [self dismissViewControllerAnimated:YES completion:nil];
+                       }
+                       // handle non-fatal error
+                   }];
     } else {
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Error" message:@"you need to create a card token before you can do a pre auth" preferredStyle:UIAlertControllerStyleAlert];
         [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];

--- a/Example-Swift/JudoKitSwiftExample/ViewController.swift
+++ b/Example-Swift/JudoKitSwiftExample/ViewController.swift
@@ -130,7 +130,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     @IBAction func AVSValueChanged(theSwitch: UISwitch) {
-        JudoKit.sharedInstance.avsEnabled = theSwitch.on
+        JudoKit.avsEnabled = theSwitch.on
     }
     
     // TODO: need to think of a way to add or remove certain card type acceptance as samples
@@ -175,7 +175,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     // MARK: Operations
     
     func paymentOperation() {
-        JudoKit.sharedInstance.payment(judoID, amount: Amount(35.0, currentCurrency), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
+        JudoKit.payment(judoID, amount: Amount(35.0, currentCurrency), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
             if let _ = error {
                 self.alertController = UIAlertController(title: "Error", message: "there was an error performing the operation", preferredStyle: .Alert)
                 self.alertController!.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
@@ -189,11 +189,16 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             let viewController = sb.instantiateViewControllerWithIdentifier("detailviewcontroller") as! DetailViewController
             viewController.response = response
             self.navigationController?.pushViewController(viewController, animated: true)
+            }, errorHandler: { (error) -> () in
+                if error.code == JudoError.UserDidCancel.rawValue {
+                    self.dismissViewControllerAnimated(true, completion: nil)
+                }
+                // handle other errors that may encounter
         })
     }
     
     func preAuthOperation() {
-        JudoKit.sharedInstance.preAuth(judoID, amount: Amount(40, currentCurrency), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
+        JudoKit.preAuth(judoID, amount: Amount(40, currentCurrency), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
             if let _ = error {
                 self.alertController = UIAlertController(title: "Error", message: "there was an error performing the operation", preferredStyle: .Alert)
                 self.alertController!.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
@@ -207,11 +212,16 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             let viewController = sb.instantiateViewControllerWithIdentifier("detailviewcontroller") as! DetailViewController
             viewController.response = response
             self.navigationController?.pushViewController(viewController, animated: true)
+            }, errorHandler: { (error) -> () in
+                if error.code == JudoError.UserDidCancel.rawValue {
+                    self.dismissViewControllerAnimated(true, completion: nil)
+                }
+                // handle other errors that may encounter
         })
     }
     
     func createCardTokenOperation() {
-        JudoKit.sharedInstance.registerCard(judoID, amount: Amount(1), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
+        JudoKit.registerCard(judoID, amount: Amount(1), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), completion: { (response, error) -> () in
             if let _ = error {
                 self.alertController = UIAlertController(title: "Error", message: "there was an error performing the operation", preferredStyle: .Alert)
                 self.alertController!.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
@@ -221,12 +231,17 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 self.cardDetails = transactionData.cardDetails
                 self.paymentToken = transactionData.paymentToken()
             }
+            }, errorHandler: { (error) -> () in
+                if error.code == JudoError.UserDidCancel.rawValue {
+                    self.dismissViewControllerAnimated(true, completion: nil)
+                }
+                // handle other errors that may encounter
         })
     }
     
     func repeatPaymentOperation() {
         if let cardDetails = self.cardDetails, let payToken = self.paymentToken {
-            JudoKit.sharedInstance.tokenPayment(judoID, amount: Amount(30), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), cardDetails: cardDetails, paymentToken: payToken, completion: { (response, error) -> () in
+            JudoKit.tokenPayment(judoID, amount: Amount(30), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), cardDetails: cardDetails, paymentToken: payToken, completion: { (response, error) -> () in
                 if let _ = error {
                     self.alertController = UIAlertController(title: "Error", message: "there was an error performing the operation", preferredStyle: .Alert)
                     self.alertController!.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
@@ -240,6 +255,11 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 let viewController = sb.instantiateViewControllerWithIdentifier("detailviewcontroller") as! DetailViewController
                 viewController.response = response
                 self.navigationController?.pushViewController(viewController, animated: true)
+                }, errorHandler: { (error) -> () in
+                    if error.code == JudoError.UserDidCancel.rawValue {
+                        self.dismissViewControllerAnimated(true, completion: nil)
+                    }
+                    // handle other errors that may encounter
             })
         } else {
             let alert = UIAlertController(title: "Error", message: "you need to create a card token before making a repeat payment or preauth operation", preferredStyle: .Alert)
@@ -250,7 +270,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     func repeatPreAuthOperation() {
         if let cardDetails = self.cardDetails, let payToken = self.paymentToken {
-            JudoKit.sharedInstance.tokenPreAuth(judoID, amount: Amount(30), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), cardDetails: cardDetails, paymentToken: payToken, completion: { (response, error) -> () in
+            JudoKit.tokenPreAuth(judoID, amount: Amount(30), reference: Reference(consumerRef: "payment reference", paymentRef: "consumer reference"), cardDetails: cardDetails, paymentToken: payToken, completion: { (response, error) -> () in
                 if let _ = error {
                     self.alertController = UIAlertController(title: "Error", message: "there was an error performing the operation", preferredStyle: .Alert)
                     self.alertController!.addAction(UIAlertAction(title: "OK", style: .Cancel, handler: nil))
@@ -264,6 +284,11 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 let viewController = sb.instantiateViewControllerWithIdentifier("detailviewcontroller") as! DetailViewController
                 viewController.response = response
                 self.navigationController?.pushViewController(viewController, animated: true)
+                }, errorHandler: { (error) -> () in
+                    if error.code == JudoError.UserDidCancel.rawValue {
+                        self.dismissViewControllerAnimated(true, completion: nil)
+                    }
+                    // handle other errors that may encounter
             })
         } else {
             let alert = UIAlertController(title: "Error", message: "you need to create a card token before making a repeat payment or preauth operation", preferredStyle: .Alert)

--- a/Source/JudoKit.swift
+++ b/Source/JudoKit.swift
@@ -26,18 +26,12 @@ import Foundation
 import Judo
 
 public typealias TransactionBlock = (Response?, NSError?) -> ()
-public typealias ErrorHandlerBlock = (NSError?) -> ()
+public typealias ErrorHandlerBlock = NSError -> ()
 
-@objc public class JudoKit: NSObject, JPayViewDelegate {
-    
-    static public let sharedInstance = JudoKit()
-    
-    private var completionBlock: TransactionBlock?
-    private var errorHandlerBlock: ErrorHandlerBlock?
-    
+@objc public class JudoKit: NSObject {
     
     /// set the address verification service to true to prompt the user to input his country and post code information
-    public var avsEnabled: Bool = false
+    public static var avsEnabled: Bool = false
     
     
     /**
@@ -50,7 +44,7 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
         Judo.setToken(token, secret: secret)
     }
     
-
+    
     /**
     set the app to sandboxed mode
     
@@ -76,16 +70,15 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a JSON Dictionary or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    @objc public func payment(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ())?, errorHandler: ErrorHandlerBlock? = nil) {
+    @objc static public func payment(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ()), errorHandler: ErrorHandlerBlock) {
         let complBlock: TransactionBlock = { (response, error) in
             var respArray: [AnyObject]? = nil
             if let response = response {
                 respArray = response.items.map { $0.rawData }
             }
-            if let completion = completion {
-                completion(respArray, error)
-            }
+            completion(respArray, error)
         }
+        
         let ref = Reference(consumerRef: consRef, paymentRef: payRef, metaData: metaData)
         self.payment(judoID, amount: Amount(amount, currency), reference: ref, completion: complBlock, errorHandler: errorHandler)
     }
@@ -100,10 +93,8 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a Response Object or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    public func payment(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock?, errorHandler: ErrorHandlerBlock? = nil) {
-        self.completionBlock = completion
-        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference)
-        vc.delegate = self
+    static public func payment(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock, errorHandler: ErrorHandlerBlock) {
+        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, completion: completion, encounteredError: errorHandler)
         UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
@@ -120,15 +111,13 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a JSON Dictionary or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    @objc public func preAuth(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ())?, errorHandler: ErrorHandlerBlock? = nil) {
+    @objc static public func preAuth(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ()), errorHandler: ErrorHandlerBlock) {
         let complBlock: TransactionBlock = { (response, error) in
             var respArray: [AnyObject]? = nil
             if let response = response {
                 respArray = response.items.map { $0.rawData }
             }
-            if let completion = completion {
-                completion(respArray, error)
-            }
+            completion(respArray, error)
         }
         let ref = Reference(consumerRef: consRef, paymentRef: payRef, metaData: metaData)
         self.preAuth(judoID, amount: Amount(amount, currency), reference: ref, completion: complBlock, errorHandler: errorHandler)
@@ -144,10 +133,8 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a Response Object or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    public func preAuth(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock?, errorHandler: ErrorHandlerBlock? = nil) {
-        self.completionBlock = completion
-        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .PreAuth)
-        vc.delegate = self
+    static public func preAuth(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock, errorHandler: ErrorHandlerBlock) {
+        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .PreAuth, completion: completion, encounteredError: errorHandler)
         UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
@@ -167,15 +154,13 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a JSON Dictionary or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    @objc public func registerCard(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ())?, errorHandler: ErrorHandlerBlock? = nil) {
+    @objc static public func registerCard(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, completion: (([AnyObject]?, NSError?) -> ()), errorHandler: ErrorHandlerBlock) {
         let complBlock: TransactionBlock = { (response, error) in
             var respArray: [AnyObject]? = nil
             if let response = response {
                 respArray = response.items.map { $0.rawData }
             }
-            if let completion = completion {
-                completion(respArray, error)
-            }
+            completion(respArray, error)
         }
         let ref = Reference(consumerRef: consRef, paymentRef: payRef, metaData: metaData)
         self.registerCard(judoID, amount: Amount(amount, currency), reference: ref, completion: complBlock, errorHandler: errorHandler)
@@ -191,10 +176,8 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a Response Object or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    public func registerCard(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock?, errorHandler: ErrorHandlerBlock? = nil) {
-        self.completionBlock = completion
-        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .RegisterCard)
-        vc.delegate = self
+    static public func registerCard(judoID: String, amount: Amount, reference: Reference, completion: TransactionBlock, errorHandler: ErrorHandlerBlock) {
+        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .RegisterCard, completion: completion, encounteredError: errorHandler)
         UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
@@ -216,15 +199,13 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:     the completion handler which will respond with a JSON Dictionary or an NSError
     - parameter errorHandler:   arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    @objc public func tokenPayment(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, cardDetails: [String:String], consumerToken: String, completion: (([AnyObject]?, NSError?) -> ())?, errorHandler: ErrorHandlerBlock? = nil) {
+    @objc static public func tokenPayment(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, cardDetails: [String:String], consumerToken: String, completion: (([AnyObject]?, NSError?) -> ()), errorHandler: ErrorHandlerBlock) {
         let complBlock: TransactionBlock = { (response, error) in
             var respArray: [AnyObject]? = nil
             if let response = response {
                 respArray = response.items.map { $0.rawData }
             }
-            if let completion = completion {
-                completion(respArray, error)
-            }
+            completion(respArray, error)
         }
         let ref = Reference(consumerRef: consRef, paymentRef: payRef, metaData: metaData)
         let payToken = PaymentToken(consumerToken: consumerToken, cardToken: cardDetails["cardToken"])
@@ -243,10 +224,8 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a Response Object or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    public func tokenPayment(judoID: String, amount: Amount, reference: Reference, cardDetails: CardDetails, paymentToken: PaymentToken, completion: TransactionBlock?, errorHandler: ErrorHandlerBlock? = nil) {
-        self.completionBlock = completion
-        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .Payment, cardDetails: cardDetails, paymentToken: paymentToken)
-        vc.delegate = self
+    static public func tokenPayment(judoID: String, amount: Amount, reference: Reference, cardDetails: CardDetails, paymentToken: PaymentToken, completion: TransactionBlock, errorHandler: ErrorHandlerBlock) {
+        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .Payment, completion: completion, encounteredError: errorHandler, cardDetails: cardDetails, paymentToken: paymentToken)
         UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
@@ -265,15 +244,13 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:     the completion handler which will respond with a JSON Dictionary or an NSError
     - parameter errorHandler:   arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    @objc public func tokenPreAuth(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, cardDetails: [String:String], consumerToken: String, completion: (([AnyObject]?, NSError?) -> ())?, errorHandler: ErrorHandlerBlock? = nil) {
+    @objc static public func tokenPreAuth(judoID: String, amount: NSDecimalNumber, currency: String? = nil, payRef: String, consRef: String, metaData: [String:String]?, cardDetails: [String:String], consumerToken: String, completion: (([AnyObject]?, NSError?) -> ()), errorHandler: ErrorHandlerBlock) {
         let complBlock: TransactionBlock = { (response, error) in
             var respArray: [AnyObject]? = nil
             if let response = response {
                 respArray = response.items.map { $0.rawData }
             }
-            if let completion = completion {
-                completion(respArray, error)
-            }
+            completion(respArray, error)
         }
         let ref = Reference(consumerRef: consRef, paymentRef: payRef, metaData: metaData)
         let payToken = PaymentToken(consumerToken: consumerToken, cardToken: cardDetails["cardToken"])
@@ -292,42 +269,9 @@ public typealias ErrorHandlerBlock = (NSError?) -> ()
     - parameter completion:   the completion handler which will respond with a Response Object or an NSError
     - parameter errorHandler: arbitrary error handler for more control to detect input or other non-fatal errors
     */
-    public func tokenPreAuth(judoID: String, amount: Amount, reference: Reference, cardDetails: CardDetails, paymentToken: PaymentToken, completion: TransactionBlock?, errorHandler: ErrorHandlerBlock? = nil) {
-        self.completionBlock = completion
-        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .PreAuth, cardDetails: cardDetails, paymentToken: paymentToken)
-        vc.delegate = self
+    static public func tokenPreAuth(judoID: String, amount: Amount, reference: Reference, cardDetails: CardDetails, paymentToken: PaymentToken, completion: TransactionBlock, errorHandler: ErrorHandlerBlock) {
+        let vc = JPayViewController(judoID: judoID, amount: amount, reference: reference, transactionType: .PreAuth, completion: completion, encounteredError: errorHandler, cardDetails: cardDetails, paymentToken: paymentToken)
         UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
-    
-    // MARK: JPayViewDelegate
-    
-    public func payViewControllerDidCancelPayment(controller: JPayViewController) {
-        if let compl = self.completionBlock {
-            compl(nil, JudoError.UserDidCancel as NSError)
-        }
-        UIApplication.sharedApplication().keyWindow?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
-    }
-    
-    public func payViewController(controller: JPayViewController, didPaySuccessfullyWithResponse response: Response) {
-        if let compl = self.completionBlock {
-            compl(response, nil)
-        }
-        UIApplication.sharedApplication().keyWindow?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
-    }
-    
-    public func payViewController(controller: JPayViewController, didFailPaymentWithError error: NSError) {
-        if let compl = self.completionBlock {
-            compl(nil, JudoError.UserDidCancel as NSError)
-        }
-        UIApplication.sharedApplication().keyWindow?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
-    }
-    
-    public func payViewController(controller: JPayViewController, didEncounterError error: NSError) {
-        if let errorHandler = self.errorHandlerBlock {
-            errorHandler(error)
-        }
-    }
-
-
 }


### PR DESCRIPTION
made main methods static
updated Swift and ObjC Example Apps to use new way of making transactions
JPayViewController now uses blocks instead of delegate pattern
passing completion and errorHandler blocks in JudoKit are now mandatory (removed optionals)