### PR TITLE
Ability to set address when AVS is off; Fix layout issues; Bump version to 7.1.0

### DIFF
--- a/Example-Swift/JudoKitSwiftExample/ViewController.swift
+++ b/Example-Swift/JudoKitSwiftExample/ViewController.swift
@@ -228,7 +228,12 @@ class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDele
     
     func paymentOperation() {
         guard let ref = Reference(consumerRef: self.reference) else { return }
-        try! self.judoKitSession.invokePayment(judoId, amount: Amount(decimalNumber: 0.01, currency: currentCurrency), reference: ref, completion: { (response, error) -> () in
+
+        // Optionally set an address to validate when AVS is turned off
+//        let address = Address(line1: "1 Long street", line2: nil, line3: nil, town: "Camborne", postCode: "TR148PA", country: .uk)
+        let address: Address? = nil
+
+        try! self.judoKitSession.invokePayment(judoId, amount: Amount(decimalNumber: 0.01, currency: currentCurrency), reference: ref, address: address, completion: { (response, error) -> () in
             self.dismissView()
             if let error = error {
                 if error.code == .userDidCancel {

--- a/JudoKit.podspec
+++ b/JudoKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'JudoKit'
-  s.version               = '7.0.1'
+  s.version               = '7.1.0'
   s.summary               = 'Judo Pay Full iOS Client Kit'
   s.homepage              = 'https://judopay.com/'
   s.license               = 'MIT'

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.0.1</string>
+	<string>7.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/JudoKit.swift
+++ b/Source/JudoKit.swift
@@ -26,7 +26,7 @@ import Foundation
 import PassKit
 import DeviceDNA
 
-let JudoKitVersion = "7.0.1"
+let JudoKitVersion = "7.1.0"
 
 /**
  A method that checks if the device it is currently running on is jailbroken or not
@@ -166,14 +166,15 @@ public class JudoKit {
     - parameter judoId:       The judoId of the merchant to receive the payment
     - parameter amount:       The amount and currency of the payment (default is GBP)
     - parameter reference:    Reference object that holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information
+    - parameter cardDetails:  Card details (optional)
+    - parameter address:      Address (optional) - will be passed through to Judo if AVS is turned off
     - parameter completion:   The completion handler which will respond with a Response Object or an NSError
     */
-    public func invokePayment(_ judoId: String, amount: Amount, reference: Reference, cardDetails: CardDetails? = nil, completion: @escaping (Response?, JudoError?) -> ()) throws {
-        let judoPayViewController = try JudoPayViewController(judoId: judoId, amount: amount, reference: reference, completion: completion, currentSession: self, cardDetails: cardDetails)
+    public func invokePayment(_ judoId: String, amount: Amount, reference: Reference, cardDetails: CardDetails? = nil, address: Address? = nil, completion: @escaping (Response?, JudoError?) -> ()) throws {
+        let judoPayViewController = try JudoPayViewController(judoId: judoId, amount: amount, reference: reference, completion: completion, currentSession: self, cardDetails: cardDetails, address: address)
         self.initiateAndShow(judoPayViewController)
     }
-    
-    
+
     /**
     Make a pre-auth using this method
     

--- a/Source/JudoPayInputField.swift
+++ b/Source/JudoPayInputField.swift
@@ -68,8 +68,6 @@ open class JudoPayInputField: UIView, UITextFieldDelegate, ErrorAnimatable {
     let hintLabel = UILabel()
     var hasRedBlockBeenLaiedout = false
     
-    var heightConstraint: NSLayoutConstraint!
-    
     // MARK: Initializers
     
     /**
@@ -152,12 +150,6 @@ open class JudoPayInputField: UIView, UITextFieldDelegate, ErrorAnimatable {
         self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[text(40)]", options: .alignAllLastBaseline, metrics: nil, views: ["text":textField]))
         self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[hintLabel]|", options: .alignAllLastBaseline, metrics: nil, views: ["hintLabel":hintLabel]))
         
-        
-        let height = self.isKind(of: BillingCountryInputField.self) || self.isKind(of: PostCodeInputField.self) ? 0.0 : self.theme.inputFieldHeight
-        self.heightConstraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: height)
-        if !self.isKind(of: SecurityInputField.self) && !self.isKind(of: IssueNumberInputField.self){
-            self.addConstraint(heightConstraint)
-        }
         self.setActive(false)
         
         textField.attributedPlaceholder = NSAttributedString(string: title(), attributes: [.foregroundColor: theme.getPlaceholderTextColor()])
@@ -346,20 +338,13 @@ extension JudoPayInputField: JudoInputType {
     public func displayHint(message: String) {
         self.hintLabel.text = message
         self.hintLabel.textColor = self.theme.getInputFieldHintTextColor()
-        self.updateConstraints(message: message)
     }
     
     public func displayError(message: String) {
         self.hintLabel.text = message
         self.hintLabel.textColor = self.theme.getErrorColor()
-        self.updateConstraints(message: message)
     }
-    
-    private func updateConstraints(message: String) {
-        heightConstraint.constant = message.isEmpty ? 50 : theme.inputFieldHeight
-        layoutIfNeeded()
-    }
-    
+
     private  func setRedBlockFrameAndBackgroundColor(height: CGFloat, backgroundColor: UIColor) {
         self.redBlock.backgroundColor = backgroundColor
         let yPosition:CGFloat = self.frame.size.height == 50 ? 4 : 22;

--- a/Source/JudoPayView.swift
+++ b/Source/JudoPayView.swift
@@ -116,7 +116,7 @@ open class JudoPayView: UIView {
         self.issueNumberInputField = IssueNumberInputField(theme: currentTheme)
         self.billingCountryInputField = BillingCountryInputField(theme: currentTheme)
         self.postCodeInputField = PostCodeInputField(theme: currentTheme)
-        
+
         self.isTokenPayment = isTokenPayment
         
         super.init(frame: UIScreen.main.bounds)
@@ -284,17 +284,18 @@ open class JudoPayView: UIView {
         self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(-1)-[billing]-(-1)-[post(==billing)]-(-1)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: ["billing":billingCountryInputField, "post":postCodeInputField]))
         
         self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(12)-[securityMessage]-(12)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: ["securityMessage":securityMessageLabel]))
-        
-        self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-75-[card(<=fieldHeight)]-(topSpacing)-[start]-(topSpacing)-[expiry(<=fieldHeight)]-(topSpacing)-[billing]-(20)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: ["fieldHeight":self.theme.inputFieldHeight, "topSpacing": verticalTopSpace], views: ["card":cardInputField, "start":startDateInputField, "expiry":expiryDateInputField, "billing":billingCountryInputField]))
-        self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-75-[card(<=fieldHeight)]-(topSpacing)-[issue(==start)]-(topSpacing)-[security(<=fieldHeight)]-(topSpacing)-[post]-(20)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: ["fieldHeight":self.theme.inputFieldHeight, "topSpacing": verticalTopSpace], views: ["card":cardInputField, "issue":issueNumberInputField, "start":startDateInputField, "security":secureCodeInputField, "post":postCodeInputField]))
-        
-        self.maestroFieldsHeightConstraint = NSLayoutConstraint(item: startDateInputField, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: 1.0)
-        self.avsFieldsHeightConstraint = NSLayoutConstraint(item: billingCountryInputField, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: self.billingCountryInputField.heightConstraint.constant)
+
+        self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-75-[card(fieldHeight)]-(topSpacing)-[start]-(topSpacing)-[expiry(fieldHeight)]-(topSpacing)-[billing]-(20)-|", options: [], metrics: ["fieldHeight":self.theme.inputFieldHeight, "topSpacing": verticalTopSpace], views: ["card":cardInputField, "start":startDateInputField, "expiry":expiryDateInputField, "billing":billingCountryInputField]))
+        self.contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-75-[card(fieldHeight)]-(topSpacing)-[issue(==start)]-(topSpacing)-[security(fieldHeight)]-(topSpacing)-[post(==billing)]-(20)-|", options: [], metrics: ["fieldHeight":self.theme.inputFieldHeight, "topSpacing": verticalTopSpace], views: ["card":cardInputField, "issue":issueNumberInputField, "start":startDateInputField, "security":secureCodeInputField, "post":postCodeInputField, "billing":billingCountryInputField]))
+
+        self.maestroFieldsHeightConstraint = NSLayoutConstraint(item: startDateInputField, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: 0)
+        self.avsFieldsHeightConstraint = NSLayoutConstraint(item: billingCountryInputField, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: 0)
         self.securityMessageTopConstraint = NSLayoutConstraint(item: securityMessageLabel, attribute: .top, relatedBy: .equal, toItem: self.postCodeInputField, attribute: .bottom, multiplier: 1.0, constant: 24.0)
         
         self.securityMessageLabel.isHidden = !(self.theme.showSecurityMessage)
 
-        self.billingCountryInputField.addConstraint(avsFieldsHeightConstraint!)        
+        self.startDateInputField.addConstraint(maestroFieldsHeightConstraint!)
+        self.billingCountryInputField.addConstraint(avsFieldsHeightConstraint!)
         self.contentView.addConstraint(securityMessageTopConstraint!)
         
         // If card details are available, fill out the fields
@@ -318,16 +319,6 @@ open class JudoPayView: UIView {
         }
     }
     
-    func clearConstraints(inputField: JudoPayInputField){
-        let array = inputField.constraints
-        for constraint in array {
-            if constraint.firstAttribute == .height {
-                inputField.removeConstraint(constraint)
-            }
-        }
-        inputField.setupView()
-    }
-    
     /**
      This method is intended to toggle the start date and issue number fields visibility when a Card has been identified.
      
@@ -336,7 +327,7 @@ open class JudoPayView: UIView {
      - parameter isVisible: Whether start date and issue number fields should be visible
      */
     open func toggleStartDateVisibility(_ isVisible: Bool) {
-        self.startDateInputField.heightConstraint.constant = isVisible ? 50 : 1
+        self.maestroFieldsHeightConstraint?.constant = isVisible ? theme.inputFieldHeight : 0
         self.issueNumberInputField.setNeedsUpdateConstraints()
         self.startDateInputField.setNeedsUpdateConstraints()
         self.startDateInputField.isVisible = isVisible
@@ -367,7 +358,7 @@ open class JudoPayView: UIView {
         if isVisible {
             self.startDateInputField.displayHint(message: "")
         }
-        
+
         UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.billingCountryInputField.layoutIfNeeded()
             self.postCodeInputField.layoutIfNeeded()

--- a/Source/JudoPayViewController.swift
+++ b/Source/JudoPayViewController.swift
@@ -65,7 +65,9 @@ open class JudoPayViewController: UIViewController {
     open fileprivate (set) var reference: Reference?
     /// Card token and Consumer token
     open fileprivate (set) var paymentToken: PaymentToken?
-    
+    /// Customer address to use when AVS is turned off
+    open private(set) var address: Address?
+
     /// The current transaction
     open let transaction: Transaction
     
@@ -107,11 +109,12 @@ open class JudoPayViewController: UIViewController {
      
      - returns: a JPayViewController object for presentation on a view stack
      */
-    public init(judoId: String, amount: Amount, reference: Reference, transactionType: TransactionType = .payment, completion: @escaping JudoCompletionBlock, currentSession: JudoKit, cardDetails: CardDetails? = nil, paymentToken: PaymentToken? = nil) throws {
+    public init(judoId: String, amount: Amount, reference: Reference, transactionType: TransactionType = .payment, completion: @escaping JudoCompletionBlock, currentSession: JudoKit, cardDetails: CardDetails? = nil, address: Address? = nil, paymentToken: PaymentToken? = nil) throws {
         self.judoId = judoId
         self.amount = amount
         self.reference = reference
         self.paymentToken = paymentToken
+        self.address = address
         self.completionBlock = completion
         
         self.judoKitSession = currentSession
@@ -255,7 +258,6 @@ open class JudoPayViewController: UIViewController {
                 transaction.paymentToken(payToken)
             } else {
                 // I expect that all the texts are available because the Pay Button would not be active otherwise
-                var address: Address? = nil
                 if self.judoKitSession.theme.avsEnabled {
                     guard let postCode = self.myView.postCodeInputField.textField.text else { return }
                     

--- a/Source/Payment.swift
+++ b/Source/Payment.swift
@@ -22,33 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Foundation
-
 open class Payment: Transaction, TransactionPath {
-    
-    /// path variable for this class
     open static var path: String { get { return "transactions/payments" } }
-    
-    
-    /**
-    If you need to check a payment before actually processing it, you can use the validate call, we'll perform our internal checks on the payment without sending it to consumer's bank. We check if the merchant identified by the judo ID can accept the payment, if the card can be accepted and if the card number passes the LUHN test.
-    
-    - Parameter block: a completion block that is called when the request finishes
-    
-    - Returns: reactive Self
-    */
-    open func validate(_ block: @escaping (JudoCompletionBlock)) throws -> Self {
-        if (self.card != nil && self.payToken != nil) {
-            throw JudoError(.cardAndTokenError)
-        } else if self.card == nil && self.payToken == nil {
-            throw JudoError(.cardOrTokenMissingError)
-        }
-        
-        self.APISession?.POST(type(of: self).path + "/validate", parameters: self.parameters) { (dict, error) -> Void in
-            block(dict, error)
-        }
-
-        return self
-    }
-
 }

--- a/Tests/PaymentTests.swift
+++ b/Tests/PaymentTests.swift
@@ -361,37 +361,6 @@ class PaymentTests: JudoTestCase {
         }
         XCTAssertTrue(parameterError)
     }
-    
-    // TODO: Investigate. Test is disabled because the API returns not_Found instead of validation_Passed
-    func testJudoValidation() {
-        // Given
-        guard let references = Reference(consumerRef: "consumer0053252") else { return }
-        let card = Card(number: "4976000000003436", expiryDate: "12/20", securityCode: "452")
-        let amount = Amount(amountString: "30", currency: .GBP)
-        let emailAddress = "hans@email.com"
-        let mobileNumber = "07100000000"
-
-        let expectation = self.expectation(description: "payment expectation")
-        
-        // When
-        do {
-            let makePayment = try judo.payment(myJudoId, amount: amount, reference: references).card(card).contact(mobileNumber, emailAddress).validate { dict, error in
-                if let error = error {
-                    XCTAssertEqual(error.code, JudoErrorCode.validation_Passed)
-                } else {
-                    XCTFail("api call did not respond with an error")
-                }
-                expectation.fulfill()
-            }
-            // Then
-            XCTAssertNotNil(makePayment)
-            XCTAssertEqual(makePayment.judoId, myJudoId)
-        } catch {
-            XCTFail("exception thrown: \(error)")
-        }
-        self.waitForExpectations(timeout: 30.0, handler: nil)
-        
-    }
 
     func testVCOPayment() {
         do {

--- a/Tests/PaymentTests.swift
+++ b/Tests/PaymentTests.swift
@@ -362,7 +362,7 @@ class PaymentTests: JudoTestCase {
         XCTAssertTrue(parameterError)
     }
     
-    
+    // TODO: Investigate. Test is disabled because the API returns not_Found instead of validation_Passed
     func testJudoValidation() {
         // Given
         guard let references = Reference(consumerRef: "consumer0053252") else { return }


### PR DESCRIPTION
Note: testJudoValidation is disabled at the moment because the API returns not_Found instead of validation_Passed - that's on endpoint /transactions/payments/validate. @mikehancock do you know what could cause this? wrong consumerReference, email or mobile number are sent or the api changed?